### PR TITLE
Add pull request, contribution templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Got a question about adding something?
+
+If it's a "how do I do X" question, try asking in the Code for Australia slack first.
+
+If it's a "what about including [some-info] in this repo" question, you have 2 options:
+
+## 1. Open a pull request
+
+Clone the repository into your local machine: `git clone https://github.com/CodeforAustralia/fellowship_brain.git`
+
+Make a branch, using a terse but meaningful name: `git checkout -b your-branch-name`
+
+
+Introduce your [changes](https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line/), and open a [pull request](https://help.github.com/articles/creating-a-pull-request/). Ask in the Code for Australia slack for someone to peer-review your pull request. Reviewers typically leave a :+1: to signify their approval. If they suggest changes, discuss them in the pull request and make additional changes to your branch.
+
+Once you have approval, you can merge your pull request. Look for the big green button at the bottom of the page.
+
+## 2. Open an issue
+
+Don't feel comfortable or ready to open a pull request? [Open an issue](https://github.com/CodeforAustralia/fellowship_brain/issues/new) instead. Provide as much detail as you can, then ask in the Code for Australia slack for people to review and comment on your issue.
+
+Hopefully, that discussion will lead to a pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Why
+
+# What
+
+<!--
+Uncomment this if there is a relevant slack / gdoc link to share
+# References
+
+- the-link
+
+-->
+
+# Merge checklist
+
+- [ ] :+1: from a peer-review

--- a/README.md
+++ b/README.md
@@ -20,8 +20,3 @@ content will be added against these initial topics as mentoring time permits
 
   - [coming soon] [meet the current mentors](./mentors.md)
   - [in progress] [previous cohorts](./archives/README.md) contains project briefs, meeting minutes from previous fellowship groups
-
-# How to contribute
-
-- Open an issue requesting clarification of an existing topic, or information on a new topic
-- Open a pull request with proposed changes and seek a peer review from other fellows and mentors


### PR DESCRIPTION
# Why

We want the barrier to participation to be low while employing best practices. Contributing and Pull Request templates help convey expectation in a straightforward manner.

# What

- Github `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md` templates added
- Removed artisanal `Contributing` section from the README